### PR TITLE
fix: 修复本地go run  main.go启动应用时报错Version和CurrentCommit这2个变量undefined的问题

### DIFF
--- a/init.go
+++ b/init.go
@@ -15,9 +15,6 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-var Version = "unknown"
-var CurrentCommit = "unknown"
-
 var TempLog string
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,11 @@ import (
 	"github.com/beck-8/subs-check/app"
 )
 
+var (
+	Version = "unknown"
+	CurrentCommit = "unknown"
+)
+
 func main() {
 	application := app.New(fmt.Sprintf("%s-%s", Version, CurrentCommit))
 	slog.Info(fmt.Sprintf("当前版本: %s-%s", Version, CurrentCommit))


### PR DESCRIPTION
```bash
➜ go run .\main.go -f .\config\config.yaml        
# command-line-arguments
.\main.go:12:46: undefined: Version
.\main.go:12:55: undefined: CurrentCommit
.\main.go:13:47: undefined: Version
.\main.go:13:56: undefined: CurrentCommit
```
更新为在main.go中定义并初始化这两个变量，这样初始化后在init.go中也能取到变量的值因为都是在`package main`中，在构建过程中`go build -ldflags="-X main.Version=v1.2.3 -X main.CurrentCommit=abcdef"`这种方式编译也是可以把这两个变量初始化的值注入进来的