### PR TITLE
feat(substore): 更新时不覆盖用户在 sub-store 的改动

### DIFF
--- a/utils/substore.go
+++ b/utils/substore.go
@@ -16,48 +16,72 @@ import (
 	"github.com/beck-8/subs-check/config"
 )
 
+// 订阅对象，对应 sub-store /api/sub 的字段。
+// 参考: ../sub-store/backend/src/restful/subscriptions.js
+// 我们只写入需要的字段，其余加 omitempty 仅作字段说明，不会序列化。
 type sub struct {
-	Content string           `json:"content"`
-	Name    string           `json:"name"`
-	Remark  string           `json:"remark"`
-	Source  string           `json:"source"`
-	Process []map[string]any `json:"process"`
+	Name                  string     `json:"name"`
+	DisplayName           string     `json:"displayName,omitempty"`
+	Source                string     `json:"source"` // local | remote
+	URL                   string     `json:"url,omitempty"`
+	Content               string     `json:"content,omitempty"`
+	UA                    string     `json:"ua,omitempty"`
+	MergeSources          string     `json:"mergeSources,omitempty"`
+	IgnoreFailedRemoteSub bool       `json:"ignoreFailedRemoteSub,omitempty"`
+	Proxy                 string     `json:"proxy,omitempty"`
+	Process               []Operator `json:"process,omitempty"`
+	Remark                string     `json:"remark,omitempty"`
+	Tag                   []string   `json:"tag,omitempty"`
+	SubscriptionTags      []string   `json:"subscriptionTags,omitempty"`
 }
 
-type subResult struct {
-	Data   sub    `json:"data"`
-	Status string `json:"status"`
+// 文件对象，对应 sub-store /api/file 的字段。
+// 参考: ../sub-store/backend/src/restful/file.js
+type file struct {
+	Name                   string     `json:"name"`
+	DisplayName            string     `json:"displayName,omitempty"`
+	Source                 string     `json:"source"`               // local | remote
+	SourceType             string     `json:"sourceType,omitempty"` // subscription | collection
+	SourceName             string     `json:"sourceName,omitempty"`
+	Type                   string     `json:"type"` // mihomoProfile | ...
+	URL                    string     `json:"url,omitempty"`
+	Content                string     `json:"content,omitempty"`
+	UA                     string     `json:"ua,omitempty"`
+	MergeSources           string     `json:"mergeSources,omitempty"`
+	IgnoreFailedRemoteFile bool       `json:"ignoreFailedRemoteFile,omitempty"`
+	Proxy                  string     `json:"proxy,omitempty"`
+	Process                []Operator `json:"process,omitempty"`
+	Remark                 string     `json:"remark,omitempty"`
 }
 
-type args struct {
+// 处理算子 (process item)。sub-store 中 args 的类型随算子而变：
+// Script/Quick Setting Operator 为对象，Sort Operator 为字符串 "asc"，
+// Regex 系为字符串/数组等，故 Args 用 any。
+// 参考: ../sub-store/backend/src/core/proxy-utils/processors/index.js
+type Operator struct {
+	Type       string `json:"type"`
+	Args       any    `json:"args,omitempty"`
+	Disabled   bool   `json:"disabled,omitempty"`
+	CustomName string `json:"customName,omitempty"` // 用作我们覆写算子的识别标记
+}
+
+// Script Operator 的 args
+type scriptArgs struct {
 	Content string `json:"content"`
 	Mode    string `json:"mode"`
 }
 
-type Operator struct {
-	Args     args   `json:"args"`
-	Disabled bool   `json:"disabled"`
-	Type     string `json:"type"`
-}
-
-type file struct {
-	Name       string     `json:"name"`
-	Process    []Operator `json:"process"`
-	Remark     string     `json:"remark"`
-	Source     string     `json:"source"`
-	SourceName string     `json:"sourceName"`
-	SourceType string     `json:"sourceType"`
-	Type       string     `json:"type"`
-}
-
-type fileResult struct {
-	Data   file   `json:"data"`
+// 仅用于检查接口返回是否成功；不解析 data，因为 Operator 的 args 类型不固定，强解析会失败。
+type statusResult struct {
 	Status string `json:"status"`
 }
 
 const (
 	SubName    = "sub"
 	MihomoName = "mihomo"
+	// 我们覆写算子的识别标记，写在 process item 的 customName 上。
+	// sub-store 处理时只读 type/args/disabled，customName 仅作前端展示，可安全用作标记。
+	overwriteOpMarker = "subs-check专用,勿动"
 )
 
 // 用来判断用户是否在运行时更改了覆写订阅的url
@@ -108,7 +132,6 @@ func UpdateSubStore(yamlData []byte) {
 			return
 		}
 		mihomoOverwriteUrl = config.GlobalConfig.MihomoOverwriteUrl
-		slog.Debug("mihomo覆写订阅url已更新")
 	}
 	slog.Info("substore更新完成")
 }
@@ -122,12 +145,16 @@ func checkSub() error {
 	if err != nil {
 		return err
 	}
-	var fileResult fileResult
-	err = json.Unmarshal(body, &fileResult)
-	if err != nil {
-		return err
+	// sub-store 对不存在的 sub 会返回 500 + HTML(而非干净的 JSON),
+	// 先判状态码,避免把 HTML 丢给 json 解析报出 "invalid character '<'" 这种迷惑日志
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("sub 不存在或 sub-store 未就绪 (HTTP %d)", resp.StatusCode)
 	}
-	if fileResult.Status != "success" {
+	var result statusResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("解析 sub 响应失败: %w", err)
+	}
+	if result.Status != "success" {
 		return fmt.Errorf("获取sub配置文件失败")
 	}
 	return nil
@@ -139,10 +166,8 @@ func createSub(data []byte) error {
 		Name:    "sub",
 		Remark:  "subs-check专用,勿动",
 		Source:  "local",
-		Process: []map[string]any{
-			{
-				"type": "Quick Setting Operator",
-			},
+		Process: []Operator{
+			{Type: "Quick Setting Operator"},
 		},
 	}
 	json, err := json.Marshal(sub)
@@ -161,25 +186,15 @@ func createSub(data []byte) error {
 }
 
 func updateSub(data []byte) error {
-
-	sub := sub{
-		Content: string(data),
-		Name:    "sub",
-		Remark:  "subs-check专用,勿动",
-		Source:  "local",
-		Process: []map[string]any{
-			{
-				"type": "Quick Setting Operator",
-			},
-		},
-	}
-	json, err := json.Marshal(sub)
+	// PATCH 是浅合并 ({...old, ...body})，只发 content 即可刷新节点，
+	// 用户对 sub 的其它改动 (process/remark/tag 等) 都会保留。
+	payload, err := json.Marshal(map[string]string{"content": string(data)})
 	if err != nil {
 		return err
 	}
 	req, err := http.NewRequest(http.MethodPatch,
 		fmt.Sprintf("%s/api/sub/%s", BaseURL, SubName),
-		bytes.NewBuffer(json))
+		bytes.NewBuffer(payload))
 	if err != nil {
 		return err
 	}
@@ -205,12 +220,14 @@ func checkfile() error {
 	if err != nil {
 		return err
 	}
-	var fileResult fileResult
-	err = json.Unmarshal(body, &fileResult)
-	if err != nil {
-		return err
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("mihomo 文件不存在或 sub-store 未就绪 (HTTP %d)", resp.StatusCode)
 	}
-	if fileResult.Status != "success" {
+	var result statusResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("解析 mihomo 文件响应失败: %w", err)
+	}
+	if result.Status != "success" {
 		return fmt.Errorf("获取mihomo配置文件失败")
 	}
 	return nil
@@ -220,12 +237,12 @@ func createfile() error {
 		Name: MihomoName,
 		Process: []Operator{
 			{
-				Args: args{
+				Type: "Script Operator",
+				Args: scriptArgs{
 					Content: WarpUrl(config.GlobalConfig.MihomoOverwriteUrl),
 					Mode:    "link",
 				},
-				Disabled: false,
-				Type:     "Script Operator",
+				CustomName: overwriteOpMarker,
 			},
 		},
 		Remark:     "subs-check专用,勿动",
@@ -250,36 +267,92 @@ func createfile() error {
 }
 
 func updatefile() error {
-	file := file{
-		Name: MihomoName,
-		Process: []Operator{
-			{
-				Args: args{
-					Content: WarpUrl(config.GlobalConfig.MihomoOverwriteUrl),
-					Mode:    "link",
-				},
-				Disabled: false,
-				Type:     "Script Operator",
-			},
-		},
-		Remark:     "subs-check专用,勿动",
-		Source:     "local",
-		SourceName: "sub",
-		SourceType: "subscription",
-		Type:       "mihomoProfile",
+	// 把现有 file 整个拉出来，只改我们自己的 Script Operator 的覆写 URL，
+	// 再用 PATCH (浅合并) 只发回 process。这样用户加的其它算子和文件的其它字段都保留。
+	resp, err := http.Get(fmt.Sprintf("%s/api/wholeFile/%s", BaseURL, MihomoName))
+	if err != nil {
+		return err
 	}
-	json, err := json.Marshal(file)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	var result struct {
+		Data struct {
+			Process []map[string]any `json:"process"`
+		} `json:"data"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return err
+	}
+	if result.Status != "success" {
+		return fmt.Errorf("获取mihomo配置文件失败")
+	}
+
+	newContent := WarpUrl(config.GlobalConfig.MihomoOverwriteUrl)
+	process := result.Data.Process
+	found := false
+	changed := false
+
+	// 1) 优先按标记找我们的算子，避免和用户自己加的 Script Operator 混淆
+	for _, op := range process {
+		if op["customName"] != overwriteOpMarker {
+			continue
+		}
+		found = true
+		if a, ok := op["args"].(map[string]any); ok {
+			if c, _ := a["content"].(string); c != newContent {
+				a["content"] = newContent
+				changed = true
+			}
+		}
+		break
+	}
+	// 2) 兼容老数据(标记出现前创建的)：取第一个 mode=link 的 Script Operator，
+	//    改 content 的同时补上标记，之后就能精确匹配
+	if !found {
+		for _, op := range process {
+			if op["type"] != "Script Operator" {
+				continue
+			}
+			if a, ok := op["args"].(map[string]any); ok && a["mode"] == "link" {
+				a["content"] = newContent
+				op["customName"] = overwriteOpMarker
+				found = true
+				changed = true
+				break
+			}
+		}
+	}
+	// 3) 都没有(用户删了)，把带标记的算子放到最前面
+	if !found {
+		process = append([]map[string]any{{
+			"type":       "Script Operator",
+			"args":       map[string]any{"content": newContent, "mode": "link"},
+			"customName": overwriteOpMarker,
+		}}, process...)
+		changed = true
+	}
+
+	// 内容没有变化就不发 PATCH，也不打日志——避免"我没改却每次都说已更新"
+	if !changed {
+		return nil
+	}
+
+	payload, err := json.Marshal(map[string]any{"process": process})
 	if err != nil {
 		return err
 	}
 	req, err := http.NewRequest(http.MethodPatch,
 		fmt.Sprintf("%s/api/file/%s", BaseURL, MihomoName),
-		bytes.NewBuffer(json))
+		bytes.NewBuffer(payload))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -287,6 +360,7 @@ func updatefile() error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("更新mihomo配置文件失败,错误码:%d", resp.StatusCode)
 	}
+	slog.Debug("mihomo覆写订阅url已更新")
 	return nil
 }
 

--- a/utils/substore.go
+++ b/utils/substore.go
@@ -16,6 +16,39 @@ import (
 	"github.com/beck-8/subs-check/config"
 )
 
+// ============================================================================
+// sub-store 数据模型速览(后端是 schemaless 的,数据以 JSON 存盘,字段即下面这些)
+//
+// 两种顶层对象:
+//   - subscription(订阅)  /api/sub/:name   —— 一组节点的来源。我们用名为 "sub"
+//     的本地订阅(source=local)装检测后的节点(content 字段,yaml)。见 sub 结构体。
+//   - file(文件)         /api/file/:name  —— 由某个 source 生成的产物文件。我们用
+//     名为 "mihomo" 的 file(type=mihomoProfile, sourceName="sub")做 mihomo 覆写。
+//     见 file 结构体。
+//
+// 两者都带一条 process 处理流水线(数组),每项是一个算子(Operator):
+//   { type, args, disabled, customName, id }
+//   - type:     算子类型,如 "Quick Setting Operator" / "Script Operator" / "Sort Operator"
+//   - args:     参数,*类型随算子而变*(对象 / 字符串 / 数组都可能),所以这里用 any
+//   - disabled: 是否禁用
+//   - customName/id: 前端用的元数据。sub-store 后端处理时只读 type/args/disabled,
+//     customName 仅作前端显示名,故我们借它当"这是 subs-check 的算子"的标记(见 overwriteOpMarker)
+//
+// 接口要点:
+//   - 创建用 POST /api/subs、/api/files
+//   - 更新用 PATCH /api/sub/:name、/api/file/:name,是*浅合并* {...old, ...body},
+//     所以我们只发自己负责的字段,用户的其它改动会保留(见 updateSub / updatefile)
+//   - 检查只看返回的 status 字段(见 statusResult)。不存在时两个接口都返回 HTTP 500
+//     (sub-store 的 ResourceNotFoundError 把 404 误传成了 error.details,实际状态码回落到 500):
+//     /api/sub 返回 500+HTML,/api/wholeFile 返回 500+JSON(status=failed)。故先判状态码再解析。
+//   - 注意 /api/wholeFile 只返回存盘的原始对象、不做任何转换,所以 status!=success 只代表"文件不存在",
+//     不是转换失败;真正会转换/可能转换失败的是 /api/file/:name(produce,失败时 500,不存在时 404)。
+//
+// 注:下面结构体里带 omitempty 但我们不写入的字段(displayName/ua/... )仅作字段说明用。
+// 参考: ../sub-store/backend/src/restful/{subscriptions,file}.js
+//        ../sub-store/backend/src/core/proxy-utils/processors/index.js
+// ============================================================================
+
 // 订阅对象，对应 sub-store /api/sub 的字段。
 // 参考: ../sub-store/backend/src/restful/subscriptions.js
 // 我们只写入需要的字段，其余加 omitempty 仅作字段说明，不会序列化。

--- a/utils/substore_integration_test.go
+++ b/utils/substore_integration_test.go
@@ -1,0 +1,390 @@
+//go:build substore_it
+
+// 真实启动一个临时 sub-store(独立端口 + 独立数据目录),对 substore.go 的增删改查做端到端测试。
+// 默认 go test 不会跑,需要显式带 tag:
+//
+//	go test -tags substore_it ./utils/ -run TestSubStore -v
+//
+// 依赖当前平台已嵌入的 node 二进制(assets.EmbeddedNode),与正式运行用的是同一份。
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/beck-8/subs-check/config"
+	"github.com/klauspost/compress/zstd"
+)
+
+// 不能 import assets 包(会形成 assets -> save/method -> utils 的 import cycle),
+// 所以直接读 ../assets 下的 .zst 资源文件,和正式运行用的是同一份。
+func assetsDir() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "assets")
+}
+
+func nodeAssetName() string {
+	arch := runtime.GOARCH
+	switch arch {
+	case "386":
+		arch = "i386"
+	case "arm":
+		arch = "armv7"
+	}
+	return fmt.Sprintf("node_%s_%s.zst", runtime.GOOS, arch)
+}
+
+const overwriteMarker = overwriteOpMarker
+
+// startTempSubStore 在临时目录里解压并启动一个 sub-store,返回它的 BaseURL。
+// 数据写到独立的 SUB_STORE_DATA_BASE_PATH,不会碰用户的真实数据。
+func startTempSubStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	nodeName := "node"
+	if runtime.GOOS == "windows" {
+		nodeName += ".exe"
+	}
+	ad := assetsDir()
+	nodeSrc := filepath.Join(ad, nodeAssetName())
+	if _, err := os.Stat(nodeSrc); err != nil {
+		t.Skipf("当前平台没有内嵌 node 资源 (%s),跳过集成测试", nodeSrc)
+	}
+	nodePath := filepath.Join(dir, nodeName)
+	jsPath := filepath.Join(dir, "sub-store.bundle.js")
+	decodeAsset(t, nodeSrc, nodePath, 0o755)
+	decodeAsset(t, filepath.Join(ad, "sub-store.bundle.js.zst"), jsPath, 0o644)
+
+	port := freePort(t)
+	cmd := exec.Command(nodePath, jsPath)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"SUB_STORE_DATA_BASE_PATH="+dir,
+		"SUB_STORE_BACKEND_API_PORT="+port,
+		"SUB_STORE_BACKEND_API_HOST=127.0.0.1",
+		"SUB_STORE_BODY_JSON_LIMIT=30mb",
+	)
+	logFile, _ := os.Create(filepath.Join(dir, "sub-store.log"))
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("启动 sub-store 失败: %v", err)
+	}
+	t.Logf("临时 sub-store 已启动: pid=%d 端口=%s 运行目录=%s", cmd.Process.Pid, port, dir)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		if logFile != nil {
+			logFile.Close()
+		}
+	})
+
+	base := "http://127.0.0.1:" + port
+	waitReady(t, base)
+	return base
+}
+
+func decodeAsset(t *testing.T, srcPath, dst string, mode os.FileMode) {
+	t.Helper()
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatalf("read asset %s: %v", srcPath, err)
+	}
+	dec, err := zstd.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("zstd reader: %v", err)
+	}
+	defer dec.Close()
+	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		t.Fatalf("open %s: %v", dst, err)
+	}
+	if _, err := io.Copy(f, dec); err != nil {
+		f.Close()
+		t.Fatalf("decode %s: %v", dst, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close %s: %v", dst, err)
+	}
+}
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	defer l.Close()
+	return strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+}
+
+func waitReady(t *testing.T, base string) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(base + "/api/subs")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	t.Fatal("sub-store 在超时内未就绪")
+}
+
+// patchRaw 直接发一个 PATCH,用于在测试里模拟"用户在 UI 里改了配置"。
+func patchRaw(t *testing.T, url string, body any) {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPatch, url, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("patch %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("patch %s 状态码 %d", url, resp.StatusCode)
+	}
+}
+
+// getProcess 拉取 sub 或 file 的 process 和 content。
+func getProcess(t *testing.T, url string) ([]map[string]any, string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("get %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var r struct {
+		Data struct {
+			Process []map[string]any `json:"process"`
+			Content string           `json:"content"`
+		} `json:"data"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Fatalf("解析 %s 失败: %v\n%s", url, err, string(body))
+	}
+	if r.Status != "success" {
+		t.Fatalf("get %s status=%s", url, r.Status)
+	}
+	return r.Data.Process, r.Data.Content
+}
+
+func hasOperatorType(process []map[string]any, typ string) bool {
+	for _, op := range process {
+		if op["type"] == typ {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSubStoreCRUD(t *testing.T) {
+	base := startTempSubStore(t)
+
+	// substore.go 里的函数读全局,测试里设置好
+	BaseURL = base
+	config.GlobalConfig.GithubProxy = ""
+	config.GlobalConfig.MihomoOverwriteUrl = "http://127.0.0.1:9/strategy-v1.yaml"
+	mihomoOverwriteUrl = ""
+
+	// ---- sub: 创建 ----
+	if err := checkSub(); err == nil {
+		t.Fatal("sub 尚未创建,checkSub 应该失败")
+	}
+	if err := createSub([]byte("proxies:\n  - {name: a}\n")); err != nil {
+		t.Fatalf("createSub: %v", err)
+	}
+	if err := checkSub(); err != nil {
+		t.Fatalf("创建后 checkSub 应成功: %v", err)
+	}
+
+	// 模拟用户给 sub 加了一个 Sort Operator
+	subURL := base + "/api/sub/" + SubName
+	patchRaw(t, subURL, map[string]any{
+		"process": []map[string]any{
+			{"type": "Quick Setting Operator"},
+			{"type": "Sort Operator", "args": "asc", "customName": "我的排序"},
+		},
+	})
+
+	// ---- sub: 更新(只发 content),用户的 Sort Operator 必须保留 ----
+	if err := updateSub([]byte("proxies:\n  - {name: b}\n  - {name: c}\n")); err != nil {
+		t.Fatalf("updateSub: %v", err)
+	}
+	proc, content := getProcess(t, subURL)
+	if !hasOperatorType(proc, "Sort Operator") {
+		t.Errorf("updateSub 不应覆盖用户的 Sort Operator,实际 process=%v", proc)
+	}
+	if !bytes.Contains([]byte(content), []byte("name: b")) {
+		t.Errorf("updateSub 后 content 未刷新: %q", content)
+	}
+
+	// ---- file: 创建,我们的算子应带标记 ----
+	if err := checkfile(); err == nil {
+		t.Fatal("file 尚未创建,checkfile 应该失败")
+	}
+	if err := createfile(); err != nil {
+		t.Fatalf("createfile: %v", err)
+	}
+	if err := checkfile(); err != nil {
+		t.Fatalf("创建后 checkfile 应成功: %v", err)
+	}
+	fileURL := base + "/api/file/" + MihomoName
+	proc, _ = getProcess(t, base+"/api/wholeFile/"+MihomoName)
+	if !markerPresent(proc) {
+		t.Fatalf("createfile 后应有 customName 标记,实际 process=%v", proc)
+	}
+
+	// 模拟用户在 file 里又加了一个自己的算子
+	ourArgs := map[string]any{"content": WarpUrl(config.GlobalConfig.MihomoOverwriteUrl), "mode": "link"}
+	patchRaw(t, fileURL, map[string]any{
+		"process": []map[string]any{
+			{"type": "Sort Operator", "args": "desc", "customName": "用户排序"},
+			{"type": "Script Operator", "args": ourArgs, "customName": overwriteMarker},
+		},
+	})
+
+	// ---- file: 更新覆写 URL,只动我们带标记的算子,用户算子保留 ----
+	config.GlobalConfig.MihomoOverwriteUrl = "http://127.0.0.1:9/strategy-v2.yaml"
+	if err := updatefile(); err != nil {
+		t.Fatalf("updatefile: %v", err)
+	}
+	proc, _ = getProcess(t, base+"/api/wholeFile/"+MihomoName)
+	if !hasOperatorType(proc, "Sort Operator") {
+		t.Errorf("updatefile 不应删除用户的 Sort Operator,实际 process=%v", proc)
+	}
+	want := WarpUrl("http://127.0.0.1:9/strategy-v2.yaml")
+	if got := markerContent(proc); got != want {
+		t.Errorf("我们算子的 content 应更新为 %q,实际 %q", want, got)
+	}
+	if c := userScriptContent(proc); c != "" {
+		t.Errorf("用户算子被误改了? 不应有变化,实际 userScript content=%q", c)
+	}
+
+	// ---- file: 幂等性——URL 没变时再次 updatefile 不应改动任何东西 ----
+	before, _ := getProcess(t, base+"/api/wholeFile/"+MihomoName)
+	if err := updatefile(); err != nil {
+		t.Fatalf("第二次 updatefile: %v", err)
+	}
+	after, _ := getProcess(t, base+"/api/wholeFile/"+MihomoName)
+	if len(after) != len(before) {
+		t.Errorf("幂等更新不应改变算子数量: before=%d after=%d", len(before), len(after))
+	}
+	if markerContent(after) != want {
+		t.Errorf("幂等更新不应改变 content: %q", markerContent(after))
+	}
+	if n := countMarker(after); n != 1 {
+		t.Errorf("幂等更新不应重复插入带标记的算子,实际个数=%d", n)
+	}
+}
+
+func countMarker(process []map[string]any) int {
+	n := 0
+	for _, op := range process {
+		if op["customName"] == overwriteMarker {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSubStoreLegacyFileMigration 验证老数据(无标记)首次更新会被识别并补上标记。
+func TestSubStoreLegacyFileMigration(t *testing.T) {
+	base := startTempSubStore(t)
+	BaseURL = base
+	config.GlobalConfig.GithubProxy = ""
+	config.GlobalConfig.MihomoOverwriteUrl = "http://127.0.0.1:9/old.yaml"
+
+	// 创建 sub(file 的 source 引用它)
+	if err := createSub([]byte("proxies: []\n")); err != nil {
+		t.Fatalf("createSub: %v", err)
+	}
+
+	// 直接 POST 一个"老格式" file:link 模式的 Script Operator,但没有 customName 标记
+	legacy := map[string]any{
+		"name": MihomoName,
+		"process": []map[string]any{
+			{"type": "Script Operator", "args": map[string]any{"content": "http://127.0.0.1:9/old.yaml", "mode": "link"}},
+		},
+		"source":     "local",
+		"sourceName": "sub",
+		"sourceType": "subscription",
+		"type":       "mihomoProfile",
+	}
+	b, _ := json.Marshal(legacy)
+	resp, err := http.Post(base+"/api/files", "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("post legacy file: %v", err)
+	}
+	resp.Body.Close()
+
+	// 更新:应按 type+mode 命中老算子,改 content 的同时补上标记
+	config.GlobalConfig.MihomoOverwriteUrl = "http://127.0.0.1:9/new.yaml"
+	if err := updatefile(); err != nil {
+		t.Fatalf("updatefile: %v", err)
+	}
+	proc, _ := getProcess(t, base+"/api/wholeFile/"+MihomoName)
+	if !markerPresent(proc) {
+		t.Errorf("老数据更新后应补上标记,实际 process=%v", proc)
+	}
+	if got, want := markerContent(proc), WarpUrl("http://127.0.0.1:9/new.yaml"); got != want {
+		t.Errorf("content 应更新为 %q,实际 %q", want, got)
+	}
+}
+
+func markerPresent(process []map[string]any) bool {
+	for _, op := range process {
+		if op["customName"] == overwriteMarker {
+			return true
+		}
+	}
+	return false
+}
+
+func markerContent(process []map[string]any) string {
+	for _, op := range process {
+		if op["customName"] != overwriteMarker {
+			continue
+		}
+		if a, ok := op["args"].(map[string]any); ok {
+			if c, ok := a["content"].(string); ok {
+				return c
+			}
+		}
+	}
+	return ""
+}
+
+// userScriptContent 返回非标记的 Script Operator 的 content(测试里期望它不变)。
+func userScriptContent(process []map[string]any) string {
+	for _, op := range process {
+		if op["type"] != "Script Operator" || op["customName"] == overwriteMarker {
+			continue
+		}
+		if a, ok := op["args"].(map[string]any); ok {
+			if c, ok := a["content"].(string); ok {
+				return c
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
- updateSub 只 PATCH content,保留用户对 sub 的算子/remark/tag
- updatefile 改为拉取-改-回写,只动带 customName 标记的覆写算子; 内容无变化时不发请求也不打日志
- Operator.args 改为 any(类型随算子而变),修复 unmarshal string 报错
- checkSub/checkfile 增加 HTTP 状态码判断,消除不存在时的 '<' 迷惑日志
- 新增真实启动临时 sub-store 的集成测试 (build tag substore_it)