### PR TITLE
fix: speedtest 钳制 bytes 上限，避免上游 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,9 @@ github-proxy: "https://custom-domain/raw/"
 3. 在配置文件中设置 `speed-test-url` 为你的 Workers 地址：
 
 ```yaml
-# 100MB
-speed-test-url: https://custom-domain/speedtest?bytes=104857600
-# 1GB
-speed-test-url: https://custom-domain/speedtest?bytes=1073741824
+# bytes 上限为 99999999（约 95.37 MiB）——上游 speed.cloudflare.com 限制 bytes 必须 < 1e8，
+# 超过会被拒（403）。worker.js 已对超限请求自动钳制到最大值，填再大也只会下发上限大小。
+speed-test-url: https://custom-domain/speedtest?bytes=99999999
 ```
 
 </details>

--- a/doc/cloudflare/worker.js
+++ b/doc/cloudflare/worker.js
@@ -98,9 +98,20 @@ const routeHandlers = {
     },
     async speedtest(request, url, env) {
         try {
-            const bytes = url.searchParams.get('bytes');
-            if (!bytes) {
+            // 上游 speed.cloudflare.com/__down 的硬上限：bytes 必须 < 100000000 (1e8, 约 95.37 MiB)。
+            // bytes >= 1e8 会被上游直接返回 403，因此这里把超限请求钳制到最大可用值再转发。
+            const MAX_BYTES = 99999999;
+            const rawBytes = url.searchParams.get('bytes');
+            if (!rawBytes) {
                 return handleError('请提供测试大小(bytes)', 400);
+            }
+
+            let bytes = parseInt(rawBytes, 10);
+            if (isNaN(bytes) || bytes <= 0) {
+                return handleError('bytes 必须为正整数', 400);
+            }
+            if (bytes > MAX_BYTES) {
+                bytes = MAX_BYTES; // 超过上游上限，钳制到最大值，避免 403
             }
 
             const speedTestUrl = `https://speed.cloudflare.com/__down?bytes=${bytes}`;


### PR DESCRIPTION
speed.cloudflare.com/__down 限制 bytes 必须 < 1e8（约 95.37 MiB）， 超过会返回 403。worker.js 现解析并校验 bytes，超限钳制到 99999999；
README 示例同步更新并注明上限。