### PR TITLE
fix: speedtest 转发补 Referer，修复大文件测速 403

### DIFF
--- a/doc/cloudflare/worker.js
+++ b/doc/cloudflare/worker.js
@@ -104,9 +104,15 @@ const routeHandlers = {
             }
 
             const speedTestUrl = `https://speed.cloudflare.com/__down?bytes=${bytes}`;
+            // speed.cloudflare.com 对 bytes >= 1e8 (约 95.37 MiB) 的请求会做来源校验：
+            // 缺少 Origin/Referer 的请求(如 subs-check/wget/curl 等非浏览器客户端)直接返回 403。
+            // 这里补上 Referer，使任意大小的测速请求都能通过；小于 1e8 时本就无此限制。
+            const headers = new Headers(request.headers);
+            headers.set('Referer', 'https://speed.cloudflare.com/');
+
             const response = await fetch(speedTestUrl, {
                 method: request.method,
-                headers: request.headers
+                headers
             });
 
             return new Response(response.body, {


### PR DESCRIPTION
speed.cloudflare.com 对 bytes >= 1e8（约 95.37 MiB）的下载请求会校验来源， 缺少 Origin/Referer 的非浏览器请求（subs-check/wget/curl 等）会被拒（403）。 worker.js 转发上游时补上 Referer，使任意大小的测速请求都能通过；
小于 1e8 时本就无此限制。

经实测：仅 Origin 或 Referer 任一即可放行，与 User-Agent 无关；
并发 30 × 100MB 全部 200，无限流。此方案替代被 #256 revert 的 #255 钳制方案。